### PR TITLE
Add moon and sun icons to theme changer toggle

### DIFF
--- a/src/app/MD/page.jsx
+++ b/src/app/MD/page.jsx
@@ -8,6 +8,49 @@ import Search from "../components/search";
 import Link from "next/link";
 import Switch from "@mui/material/Switch";
 
+const SunIcon = ({ className = "" }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <circle cx="12" cy="12" r="5" />
+    <line x1="12" y1="1" x2="12" y2="3" />
+    <line x1="12" y1="21" x2="12" y2="23" />
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+    <line x1="1" y1="12" x2="3" y2="12" />
+    <line x1="21" y1="12" x2="23" y2="12" />
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+  </svg>
+);
+
+// Moon icon component
+const MoonIcon = ({ className = "" }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+  </svg>
+);
+
 export default function MarkdownEditor() {
   const [markdown, setMarkdown] = useState("# hey");
   const [name, setName] = useState("untitled");
@@ -82,8 +125,9 @@ export default function MarkdownEditor() {
   console.log(toggle);
 
   const toggleTheme = () => {
-    localStorage.setItem("theme", !isDarkMode);
-    setIsDarkMode(!isDarkMode);
+    const newTheme = !isDarkMode;
+    setIsDarkMode(newTheme);
+    localStorage.setItem("theme", JSON.stringify(newTheme));
   };
 
   return (
@@ -141,13 +185,17 @@ export default function MarkdownEditor() {
           </div>
         </div>
         <div className="flex items-center">
-          <Switch
-            checked={isDarkMode}
-            onChange={toggleTheme}
-            color="default"
-            inputProps={{ "aria-label": "toggle dark mode" }}
-          />
-          {/* <span className="ml-2">{isDarkMode ? "Dark Mode" : "Light Mode"}</span> */}
+          <button
+            onClick={toggleTheme}
+            className="p-2 rounded-full hover:bg-opacity-20 hover:bg-gray-200 transition-colors duration-200"
+            aria-label="Toggle dark mode"
+          >
+            {isDarkMode ? (
+              <SunIcon className="text-white" />
+            ) : (
+              <MoonIcon className="text-black" />
+            )}
+          </button>
         </div>
       </nav>
       <div className="flex justify-between">

--- a/src/app/components/nav.jsx
+++ b/src/app/components/nav.jsx
@@ -9,6 +9,50 @@ import { IoMdGitPullRequest } from "react-icons/io";
 import Link from "next/link";
 import Switch from "@mui/material/Switch";
 
+// Sun icon component
+const SunIcon = ({ className = "" }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <circle cx="12" cy="12" r="5" />
+    <line x1="12" y1="1" x2="12" y2="3" />
+    <line x1="12" y1="21" x2="12" y2="23" />
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+    <line x1="1" y1="12" x2="3" y2="12" />
+    <line x1="21" y1="12" x2="23" y2="12" />
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+  </svg>
+);
+
+// Moon icon component
+const MoonIcon = ({ className = "" }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+  </svg>
+);
+
 export default function Nav({ isDarkMode, toggleTheme }) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [toggle, setToggle] = useState(false);
@@ -49,8 +93,8 @@ export default function Nav({ isDarkMode, toggleTheme }) {
   const togglePanel = () => {
     setOpen((prev) => !prev);
   };
-  const handletoggleTheme = () => {
-    localStorage.setItem("theme", !isDarkMode);
+  const handleToggleTheme = () => {
+    localStorage.setItem("theme", JSON.stringify(!isDarkMode));
     toggleTheme();
   };
   return (
@@ -264,12 +308,17 @@ export default function Nav({ isDarkMode, toggleTheme }) {
       <HamburgerMenu open={open} togglePanel={togglePanel} />
 
       <div className="flex items-center">
-        <Switch
-          checked={isDarkMode}
-          onChange={handletoggleTheme}
-          color="default"
-          inputProps={{ "aria-label": "theme toggle switch" }}
-        />
+        <button
+          onClick={handleToggleTheme}
+          className="p-2 rounded-full hover:bg-opacity-20 hover:bg-gray-200 transition-colors duration-200"
+          aria-label="Toggle dark mode"
+        >
+          {isDarkMode ? (
+            <SunIcon className="text-white" />
+          ) : (
+            <MoonIcon className="text-black" />
+          )}
+        </button>
       </div>
     </nav>
   );

--- a/src/app/components/navbar.jsx
+++ b/src/app/components/navbar.jsx
@@ -4,6 +4,49 @@ import Search from "./search";
 import Link from "next/link";
 import Switch from "@mui/material/Switch";
 
+const SunIcon = ({ className = "" }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <circle cx="12" cy="12" r="5" />
+    <line x1="12" y1="1" x2="12" y2="3" />
+    <line x1="12" y1="21" x2="12" y2="23" />
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+    <line x1="1" y1="12" x2="3" y2="12" />
+    <line x1="21" y1="12" x2="23" y2="12" />
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+  </svg>
+);
+
+// Moon icon component
+const MoonIcon = ({ className = "" }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+  </svg>
+);
+
 export function NavBar({ title, isDarkMode, toggleTheme }) {
   useEffect(() => {
     const storedTheme = localStorage.getItem("theme");
@@ -16,7 +59,7 @@ export function NavBar({ title, isDarkMode, toggleTheme }) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  const handletoggleTheme = () => {
+  const handleToggleTheme = () => {
     localStorage.setItem("theme", !isDarkMode);
     toggleTheme();
   };
@@ -36,13 +79,17 @@ export function NavBar({ title, isDarkMode, toggleTheme }) {
         <p>{title}</p>
       </Link>
       <div className="flex items-center">
-        <Search isDarkMode={isDarkMode} toggleTheme={toggleTheme} />
-        <Switch
-          checked={isDarkMode}
-          onChange={handletoggleTheme}
-          color="default"
-          inputProps={{ "aria-label": "toggle dark mode" }}
-        />
+        <button
+          onClick={handleToggleTheme}
+          className="p-2 rounded-full hover:bg-opacity-20 hover:bg-gray-200 transition-colors duration-200"
+          aria-label="Toggle dark mode"
+        >
+          {isDarkMode ? (
+            <SunIcon className="text-white" />
+          ) : (
+            <MoonIcon className="text-black" />
+          )}
+        </button>
       </div>
     </nav>
   );


### PR DESCRIPTION
This pull request addresses issue #173: "The changer icons"

Changes made:
- Added moon icon for dark theme
- Added sun icon for light theme
- Implemented these icons in the theme changer toggle

![Screenshot (215)](https://github.com/user-attachments/assets/66973d16-cf23-4b64-a5f6-8de55c6b0b11)

![Screenshot (216)](https://github.com/user-attachments/assets/019b8bfb-2638-4ac2-bf1a-6d820ff5b9dd)



This enhancement improves the user interface by providing visual cues for the current theme and the action of changing themes.

Closes #173