### PR TITLE
Add pagination to GitHub issue finder

### DIFF
--- a/src/app/gh-finder/page.jsx
+++ b/src/app/gh-finder/page.jsx
@@ -17,12 +17,14 @@ export default function GhFinder() {
   // New states
   const [searchQuery, setSearchQuery] = useState("");
   const [isAssigned, setIsAssigned] = useState(false);
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(10);
   const [maxResults, setMaxResults] = useState(10); // TODO FEATURE => Add Pages
   
   const toggleTheme = () => {
     setIsDarkMode(!isDarkMode);
   };
+
+  const resultPerPageChoices = [5, 10, 25, 50]
   
   const cacheKey =
   selected === 1 ? "webdevtools-issues" : `github-issues-100`;
@@ -198,12 +200,12 @@ export default function GhFinder() {
         toggleTheme={toggleTheme}
       />
       <div className="mt-10 flex w-screen justify-center">
-        <header className="lg:w-2/3">
-          <h1 className="relative z-10 font-sans text-lg font-bold text-center text-transparent md:text-7xl bg-clip-text bg-gradient-to-b from-neutral-200 to-neutral-600">
+        <header>
+          <h1 className="relative z-10 font-sans text-5xl font-bold text-center text-transparent md:text-7xl bg-clip-text bg-gradient-to-b from-neutral-200 to-neutral-600">
             Github Issue Finder
           </h1>
 
-          <div className="flex justify-between w-full lg:w-1/2 lg:mx-[25%] my-5 items-center">
+          <div className="flex flex-col md:flex-row justify-between w-full  lg:whitespace-nowrap my-5 items-center">
             <input
               type="text"
               className="p-2 rounded border border-gray-400"
@@ -211,7 +213,7 @@ export default function GhFinder() {
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
-            <div className="flex items-center">
+            <div className="flex items-center mx-4 my-4">
               <input
                 type="checkbox"
                 id="isAssigned"
@@ -221,9 +223,19 @@ export default function GhFinder() {
               />
               <label htmlFor="isAssigned">Is assigned</label>
             </div>
+            <div>
+              <p>Results per page</p>
+              <div className="flex justify-between">
+                {resultPerPageChoices.map(num => (
+                  <button key={num}>
+                    <span className="underline mx-1">{num}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
 
-          <div className="flex justify-between w-full lg:w-1/2 lg:mx-[25%] my-5 items-center">
+          <div className="flex justify-between w-full my-5 items-center">
             <button
               className={
                 "hover:bg-blue-800 transition-colors min-w-1/3 duration-100 p-5 rounded-full hover:text-white " +

--- a/src/app/gh-finder/page.jsx
+++ b/src/app/gh-finder/page.jsx
@@ -2,10 +2,8 @@
 import { useEffect, useState, useCallback } from "react";
 import { NavBar } from "../components/navbar";
 import Link from "next/link";
-import Image from "next/image";
 import BasicModal from "./modal";
 import Pagination from "./pagination";
-import { InsertLink, LinkOff } from "@mui/icons-material";
 
 export default function GhFinder() {
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -18,7 +16,7 @@ export default function GhFinder() {
   const [searchQuery, setSearchQuery] = useState("");
   const [isAssigned, setIsAssigned] = useState(false);
   const [currentPage, setCurrentPage] = useState(10);
-  const [maxResults, setMaxResults] = useState(10); // TODO FEATURE => Add Pages
+  const [maxResults, setMaxResults] = useState(10);
   
   const toggleTheme = () => {
     setIsDarkMode(!isDarkMode);
@@ -33,7 +31,6 @@ export default function GhFinder() {
 
   const fetchData = async (url) => {
     try {
-      console.log("FETCHING REQUESTS")
       const response = await fetch(url);
       const result = await response.json();
       return result;

--- a/src/app/gh-finder/page.jsx
+++ b/src/app/gh-finder/page.jsx
@@ -227,8 +227,8 @@ export default function GhFinder() {
               <p>Results per page</p>
               <div className="flex justify-between">
                 {resultPerPageChoices.map(num => (
-                  <button key={num}>
-                    <span className="underline mx-1">{num}</span>
+                  <button key={num} onClick={() => setMaxResults(num)}>
+                    <span className={`underline mx-1 ${num === maxResults && "text-cyan-600 font-bold"}`}>{num}</span>
                   </button>
                 ))}
               </div>

--- a/src/app/gh-finder/page.jsx
+++ b/src/app/gh-finder/page.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { NavBar } from "../components/navbar";
 import Link from "next/link";
 import Image from "next/image";
@@ -105,7 +105,16 @@ export default function GhFinder() {
     };
 
     setFilteredIssues(issuesByLabel(issuesBySearch(data)));
+    setCurrentPage(1);
   }, [data, isAssigned, searchQuery, selectedLabels]);
+
+  const getIssuesByPage = useCallback(() => {
+    const startResult = (currentPage - 1) * maxResults + 1;
+    const endResult = Math.min(currentPage * maxResults, filteredIssues.length);
+    return filteredIssues.slice(startResult - 1, endResult);
+  }, [currentPage, filteredIssues, maxResults]);
+
+  const issuesByPage = getIssuesByPage();
 
   // // New function to fetch PRs linked to issues
   // const fetchPRsForIssue = async (issue) => {
@@ -249,7 +258,7 @@ export default function GhFinder() {
           </div>
           
           :
-          filteredIssues.map((item) => (
+          issuesByPage.map((item) => (
           <div
             key={item.id}
             className="bg-slate-500 rounded-lg mb-5 last:mb-0 pl-5 py-5 flex w-full"

--- a/src/app/gh-finder/page.jsx
+++ b/src/app/gh-finder/page.jsx
@@ -4,6 +4,7 @@ import { NavBar } from "../components/navbar";
 import Link from "next/link";
 import Image from "next/image";
 import BasicModal from "./modal";
+import Pagination from "./pagination";
 import { InsertLink, LinkOff } from "@mui/icons-material";
 
 export default function GhFinder() {
@@ -16,6 +17,7 @@ export default function GhFinder() {
   // New states
   const [searchQuery, setSearchQuery] = useState("");
   const [isAssigned, setIsAssigned] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
   const [maxResults, setMaxResults] = useState(10); // TODO FEATURE => Add Pages
   
   const toggleTheme = () => {
@@ -23,7 +25,7 @@ export default function GhFinder() {
   };
   
   const cacheKey =
-  selected === 1 ? "webdevtools-issues" : `github-issues-${maxResults}`;
+  selected === 1 ? "webdevtools-issues" : `github-issues-100`;
   const cacheExpirationKey = `${cacheKey}-timestamp`;
   const cacheExpirationTime = 1000 * 60 * 30; // Cache expiration time (e.g., 30 minutes)
 
@@ -38,12 +40,14 @@ export default function GhFinder() {
     }
   };
 
+  console.log(data)
+
   // Fetch new data
   useEffect(() => {
     const url =
       selected === 1
         ? "https://api.github.com/repos/bashamega/webdevtools/issues"
-        : `https://api.github.com/search/issues?q=state:open+is:issue&per_page=${maxResults}&page=1`;
+        : `https://api.github.com/search/issues?q=state:open+is:issue&per_page=100&page=1`;
     
     const updateData = (newData) => {
       const now = new Date().getTime();
@@ -77,7 +81,7 @@ export default function GhFinder() {
       setData(JSON.parse(cachedData));
     }
 
-  }, [selected, maxResults, cacheKey, cacheExpirationKey, cacheExpirationTime]);
+  }, [selected, cacheKey, cacheExpirationKey, cacheExpirationTime]);
 
   // Filter issues by search keywords and assignment status
   useEffect(() => {
@@ -308,6 +312,12 @@ export default function GhFinder() {
           </div>
         ))}
       </div>
+      <Pagination
+        currentPage={currentPage}
+        setCurrentPage={setCurrentPage}
+        resultsPerPage={maxResults}
+        totalResults={filteredIssues.length}
+      />
     </div>
   );
 }

--- a/src/app/gh-finder/pagination.jsx
+++ b/src/app/gh-finder/pagination.jsx
@@ -11,15 +11,13 @@ export default function Pagination ({ currentPage, setCurrentPage, resultsPerPag
 
     return (
         <nav className="flex justify-center mt-4">
-            <ul className="inline-flex -space-x-px">
+            <ul className="grid justify-center rounded-2xl grid-cols-10">
                 {pageNumbers.map(number => (
                     <li key={number}>
                         <button
                             onClick={() => setCurrentPage(number)}
                             className={`
-                                border-cyan-600 hover:border-cyan-500 border-2 border-collapse w-12 h-12
-                                ${number === 1 ? "rounded-l" : ""}
-                                ${number === totalPages ? "rounded-r" : ""}
+                                border-cyan-600 hover:border-cyan-500 border-2 w-12 h-12
                                 ${
                                 currentPage === number
                                     ? 'text-gray-800 bg-cyan-600 hover:bg-cyan-500'

--- a/src/app/gh-finder/pagination.jsx
+++ b/src/app/gh-finder/pagination.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import Button from "@mui/material/Button"
+
+export default function Pagination ({ currentPage, setCurrentPage, resultsPerPage, totalResults }) {
+    const totalPages = Math.ceil(totalResults / resultsPerPage);
+
+    const pageNumbers = [];
+    for (let i = 1; i <= totalPages; i++) {
+        pageNumbers.push(i);
+    }
+
+    return (
+        <nav className="flex justify-center mt-4">
+            <ul className="inline-flex -space-x-px">
+                {pageNumbers.map(number => (
+                    <li key={number}>
+                        <button
+                            onClick={() => setCurrentPage(number)}
+                            className={`
+                                border-cyan-600 hover:border-cyan-500 border-2 border-collapse w-12 h-12
+                                ${number === 1 ? "rounded-l" : ""}
+                                ${number === totalPages ? "rounded-r" : ""}
+                                ${
+                                currentPage === number
+                                    ? 'text-gray-800 bg-cyan-600 hover:bg-cyan-500'
+                                    : 'text-gray-500 hover:text-gray-400'
+                                }
+                            `}
+                        >
+                            {number}
+                        </button>
+                    </li>
+                ))}
+            </ul>
+        </nav>
+    );
+};

--- a/src/app/gh-finder/pagination.jsx
+++ b/src/app/gh-finder/pagination.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Button from "@mui/material/Button"
 
 export default function Pagination ({ currentPage, setCurrentPage, resultsPerPage, totalResults }) {
     const totalPages = Math.ceil(totalResults / resultsPerPage);


### PR DESCRIPTION
## Description

Intended to close #242 
Added pagination and fixed the whole thing. Here's a quick overview of changes made:

Improved looks by CSS
When no items - show it instead of infinite loading
Show loading when data is actually not loaded
Fix bug when pressing clear on FILTERS would prevent changing tabs
All filters work as AND instead of god knows how
Add pages component with pages that can be clicked to change the page
Optimized css for different sizes
Add option to option to choose number of results per page

## More details
Basically, the thing was very bugged, when no issues were satisfying the chosen options, infinite loading was shown. Now it shows an informative message.

Now all the options work as AND - meaning if you have something in search, checkbox "is assigned", and filters for labels, it will show only issues that satisfy all the criteria.

The filter by labels was completely broken, working very weird, and pressing the trash button (clearing filters) was preventing the tabs from being able to change. Now all of it works.

## Further possible improvements:
So, now the info for pull requests is only fetched for issues of this repository. I think it should not be changed because the number of issues here is not so big, and because there's a limit of 60 requests per hour, it should be enough. On the other hand, fetching pull requests info for all generic github issues would not be possible because it would very quickly surpass the api limit.

Right now it fetches only 100 issues from github, saves them, and all filters only apply to the 100 issues. But it turns out, the github api's search limit is much more generous - 10 queries per minute. So it probably should be feasible to make a request to github api for each combination of labels, but that would need to be implemented well, so for examle if I in quick succession choose 3 labels, it would not send 3 requests in a second. Even though rate is very generous, it could still surpass 10 queries per minute quite quickly. Maybe adding an "apply" button or something.

## Video:
Here's a screencast of how it looks now:

https://github.com/user-attachments/assets/bef8811d-4d4e-4bd1-a29e-d0be3a824953

