### PR TITLE
Add copy button to markdown editor

### DIFF
--- a/src/app/MD/page.jsx
+++ b/src/app/MD/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import toast, { Toaster } from "react-hot-toast";
 import snarkdown from "snarkdown";
 import { saveAs } from "file-saver";
 import SearchIcon from "@mui/icons-material/Search";
@@ -115,6 +116,10 @@ export default function MarkdownEditor() {
   const copyToClipboard = async () => {
     try {
       await navigator.clipboard.writeText(markdown);
+      toast("Markdown Copied!!", {
+        duration: 1500,
+        icon: "✅",
+      });
     } catch (err) {
       console.error("Failed to copy: ", err);
     }
@@ -254,6 +259,7 @@ export default function MarkdownEditor() {
           />
         </section>
       </section>
+      <Toaster />
     </main>
   );
 }

--- a/src/app/MD/page.jsx
+++ b/src/app/MD/page.jsx
@@ -5,6 +5,7 @@ import snarkdown from "snarkdown";
 import { saveAs } from "file-saver";
 import SearchIcon from "@mui/icons-material/Search";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import Search from "../components/search";
 import Link from "next/link";
 import SunIcon from "../components/icons/sunicon";
@@ -111,6 +112,14 @@ export default function MarkdownEditor() {
     localStorage.setItem("theme", JSON.stringify(newTheme));
   };
 
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(markdown);
+    } catch (err) {
+      console.error("Failed to copy: ", err);
+    }
+  };
+
   return (
     <main
       className={`h-screen overflow-auto ${
@@ -213,7 +222,14 @@ export default function MarkdownEditor() {
       </div>
 
       <section className="flex flex-col md:flex-row w-full h-[100%] gap-3">
-        <section className="w-[96%] h-full  md:w-1/2 ml-2 mr-2 ">
+        <section className="w-[96%] h-full  md:w-1/2 ml-2 mr-2 relative">
+          <button
+            onClick={copyToClipboard}
+            className="absolute top-9 right-2 p-1 rounded hover:bg-opacity-20 hover:bg-gray-200 transition-colors duration-200"
+            aria-label="Copy to clipboard"
+          >
+            <ContentCopyIcon />
+          </button>
           <h1>Markdown</h1>
           <textarea
             className={`border p-2 h-full w-full resize-none ${


### PR DESCRIPTION
## Description
closes #267 

Adds a copy icon to the markdown editor that enables users to copy the content of the markdown file.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable):
<img width="756" alt="Screenshot 2024-08-13 at 16 18 03" src="https://github.com/user-attachments/assets/cdf837c9-1527-42d7-aa87-9ac5a50d90c4">
