### PR TITLE
added margin-bottom to box-shadow page

### DIFF
--- a/src/app/customizer/box-shadow-generator/page.jsx
+++ b/src/app/customizer/box-shadow-generator/page.jsx
@@ -109,7 +109,7 @@ const Page = () => {
             ></div>
           </div>
           <div
-            className={`w-full h-max flex flex-col justify-between rounded-2xl px-14 py-8 ${
+            className={`w-full h-max mb-36 flex flex-col justify-between rounded-2xl px-14 py-8 ${
               isDarkMode ? "bg-slate-800" : "bg-slate-500"
             } h-full`}
           >
@@ -169,7 +169,7 @@ const Page = () => {
               <h3 className="my-2 py-4 px-3 bg-gray-700 rounded-lg text-white">
                 {cssShadowStyle}
               </h3>
-              <h3 className="my-2 py-4 px-3 bg-gray-700 rounded-lg text-white">
+              <h3 className="my-2 py-4 px-3 bg-gray-700 rounded-lg text-white overflow-auto">
                 {tailwindShadowStyle}
               </h3>
               <div className="w-full relative py-2">


### PR DESCRIPTION
## Description

Added margin to the "Box shadow" page and fixed the overflowing text in the box-shadow card
Fixes #278 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable):
![before](https://github.com/user-attachments/assets/54154219-6687-4e82-8570-bb6318f3c5bf)
![after](https://github.com/user-attachments/assets/54c7d34a-17a4-4f11-aacb-7462c8ffd06b)
