### PR TITLE
Fixes #283 #281 markdown editor navbar ui fix and about page goToGithub button not visible fixed

### DIFF
--- a/src/app/MD/page.jsx
+++ b/src/app/MD/page.jsx
@@ -14,7 +14,8 @@ import MoonIcon from "../components/icons/moonicon";
 
 export default function MarkdownEditor() {
   const [markdown, setMarkdown] = useState("# hey");
-  const [name, setName] = useState("untitled");
+
+  const [name, setName] = useState(`Md-file-1`);
   const [toggle, setToggle] = useState(false);
   const [isDarkMode, setIsDarkMode] = useState(false);
   const textareaRef = useRef(null);
@@ -131,52 +132,55 @@ export default function MarkdownEditor() {
         isDarkMode ? "bg-gray-900 text-white" : "bg-white text-black"
       }`}
     >
-      <nav
-        className={`py-4 px-6 flex items-center justify-between h-[69px] ${
-          isDarkMode ? "bg-gray-800" : "bg-blue-500"
-        }`}
-      >
-        <Link
-          href="/"
-          className={`mr-2 flex border items-center p-2 hover:bg-blue-700 transition-all duration-700 rounded-lg ${
-            isDarkMode ? "border-gray-600" : ""
+      <nav>
+        <div
+          className={`py-4 px-6 flex items-center justify-between h-[69px] ${
+            isDarkMode ? "bg-gray-800" : "bg-blue-500"
           }`}
         >
-          <h1 className="text-sm md:text-2xl font-bold mr-4 ml-1">
-            Web Dev Tools
-          </h1>
-          <p className="mr-2 text-sm">MD Editor</p>
-        </Link>
-        <div className="flex items-center">
-          <input
-            value={name}
-            onChange={handleNameChange}
-            className={`outline-none border text-sm rounded p-1.5 px-2 ${
-              isDarkMode
-                ? "bg-gray-700 border-gray-600 text-white"
-                : "bg-gray-50 border-gray-300 text-gray-900"
-            }`}
-          />
-          <button
-            onClick={handleDownload}
-            className={`ml-2 mr-2 text-sm rounded p-1.5 px-2 hover:bg-gray-600 ${
-              isDarkMode
-                ? "bg-gray-700 border-gray-600 text-white"
-                : "bg-gray-300 border-gray-200 text-black"
+          <Link
+            href="/"
+            className={`mr-2 flex border items-center p-2 hover:bg-blue-700 transition-all duration-700 rounded-lg ${
+              isDarkMode ? "border-gray-600" : ""
             }`}
           >
-            Download
-          </button>
-          <div className="hidden lg:block ml-6">
-            <Search />
+            <h1 className="text-sm md:text-2xl font-bold mr-4 ml-1">
+              Web Dev Tools
+            </h1>
+            <p className="mr-2 text-sm">MD Editor</p>
+          </Link>
+          <div className="hidden  md:flex md:items-center">
+            <input
+              value={name}
+              onChange={handleNameChange}
+              className={`outline-none border text-sm rounded p-1.5 px-2 ${
+                isDarkMode
+                  ? "bg-gray-700 border-gray-600 text-white"
+                  : "bg-gray-50 border-gray-300 text-gray-900"
+              }`}
+            />
+            <button
+              onClick={handleDownload}
+              className={` ml-2 mr-2 text-sm rounded p-1.5 px-2 hover:bg-green-500 ${
+                isDarkMode
+                  ? "bg-green-700 border-green-600 text-white"
+                  : "bg-green-400 border-green-700 text-black"
+              }`}
+            >
+              Download
+            </button>
+            <div className="hidden lg:block ml-6">
+              <Search />
+            </div>
           </div>
 
-          <button onClick={searchToggle} className="lg:hidden">
+          {/* 
+          <button onClick={searchToggle} className="hidden">
             <SearchIcon
               className={`${isDarkMode ? "text-gray-400" : "text-gray-800"}`}
             />
-          </button>
-          <div
+          </button> */}
+          {/* <div
             className={`absolute w-full h-[69px] flex items-center ${
               isDarkMode ? "bg-gray-800" : "bg-blue-500"
             } ${
@@ -192,20 +196,44 @@ export default function MarkdownEditor() {
               />
               <Search />
             </div>
+          </div> */}
+          <div className="flex items-center">
+            <button
+              onClick={toggleTheme}
+              className="p-2 rounded-full hover:bg-opacity-20 hover:bg-gray-200 transition-colors duration-200"
+              aria-label="Toggle dark mode"
+            >
+              {isDarkMode ? (
+                <SunIcon className="text-white" />
+              ) : (
+                <MoonIcon className="text-black" />
+              )}
+            </button>
           </div>
         </div>
-        <div className="flex items-center">
+        <div className=" my-3 w-full flex justify-center items-center md:hidden ">
+          <input
+            value={name}
+            onChange={handleNameChange}
+            className={`outline-none border text-sm rounded p-1.5 px-2 ${
+              isDarkMode
+                ? "bg-gray-700 border-gray-600 text-white"
+                : "bg-gray-50 border-gray-300 text-gray-900"
+            }`}
+          />
           <button
-            onClick={toggleTheme}
-            className="p-2 rounded-full hover:bg-opacity-20 hover:bg-gray-200 transition-colors duration-200"
-            aria-label="Toggle dark mode"
+            onClick={handleDownload}
+            className={` ml-2 mr-2 text-sm rounded p-1.5 px-2 hover:bg-green-500 ${
+              isDarkMode
+                ? "bg-green-700 border-green-600 text-white"
+                : "bg-green-400 border-green-200 text-black"
+            }`}
           >
-            {isDarkMode ? (
-              <SunIcon className="text-white" />
-            ) : (
-              <MoonIcon className="text-black" />
-            )}
+            Download
           </button>
+          <div className="hidden lg:block ml-6">
+            <Search />
+          </div>
         </div>
       </nav>
       <div className="flex justify-between">

--- a/src/app/MD/page.jsx
+++ b/src/app/MD/page.jsx
@@ -14,8 +14,7 @@ import MoonIcon from "../components/icons/moonicon";
 
 export default function MarkdownEditor() {
   const [markdown, setMarkdown] = useState("# hey");
-
-  const [name, setName] = useState(`Md-file-1`);
+  const [name, setName] = useState("untitled");
   const [toggle, setToggle] = useState(false);
   const [isDarkMode, setIsDarkMode] = useState(false);
   const textareaRef = useRef(null);
@@ -161,10 +160,10 @@ export default function MarkdownEditor() {
             />
             <button
               onClick={handleDownload}
-              className={` ml-2 mr-2 text-sm rounded p-1.5 px-2 hover:bg-green-500 ${
+              className={`ml-2 mr-2 text-sm rounded p-1.5 px-2 hover:bg-gray-600 ${
                 isDarkMode
-                  ? "bg-green-700 border-green-600 text-white"
-                  : "bg-green-400 border-green-700 text-black"
+                  ? "bg-gray-700 border-gray-600 text-white"
+                  : "bg-gray-300 border-gray-200 text-black"
               }`}
             >
               Download
@@ -223,10 +222,10 @@ export default function MarkdownEditor() {
           />
           <button
             onClick={handleDownload}
-            className={` ml-2 mr-2 text-sm rounded p-1.5 px-2 hover:bg-green-500 ${
+            className={`ml-2 mr-2 text-sm rounded p-1.5 px-2 hover:bg-gray-600 ${
               isDarkMode
-                ? "bg-green-700 border-green-600 text-white"
-                : "bg-green-400 border-green-200 text-black"
+                ? "bg-gray-700 border-gray-600 text-white"
+                : "bg-gray-300 border-gray-200 text-black"
             }`}
           >
             Download

--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -18,10 +18,10 @@ export default function Home() {
       } min-h-screen`}
     >
       <Nav toggleTheme={toggleTheme} isDarkMode={isDarkMode} />
-      <div className="flex justify-center flex-col items-center w-full">
+      <div className="flex justify-center flex-col items-center w-full gap-3">
         <div
           id="about"
-          className="my-9 break-words block max-w-[26rem] md:max-w-[40rem] p-6 bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700"
+          className=" break-words block max-w-[26rem] md:max-w-[40rem] p-6 bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700"
         >
           <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
             About

--- a/src/app/components/nav.jsx
+++ b/src/app/components/nav.jsx
@@ -73,7 +73,7 @@ export default function Nav({ isDarkMode, toggleTheme }) {
     <nav
       className={`${
         isDarkMode ? "bg-gray-800 text-white" : "bg-blue-500 text-black"
-      } py-2 px-4 flex items-center justify-between lg:justify-around gap-1 w-full relative mb-10 max-h-[10vh] min-w-80`}
+      } py-2 px-4 flex items-center justify-between lg:justify-around gap-1 w-full relative mb-8 max-h-[10vh] min-w-80`}
     >
       <div className="flex flex-0 items-center flex-shrink">
         <Link href="/" className="group">

--- a/src/app/customizer/colorPicker/page.jsx
+++ b/src/app/customizer/colorPicker/page.jsx
@@ -72,14 +72,14 @@ export default function ColorPicker() {
           <div className="buttons flex gap-2 sm:flex-col">
             <button
               onClick={handleHex}
-              className="bg-blue-500 hover:bg-white hover:text-black hover:border-4 border-blue-700 font-bold p-4 mb-6 transition-all rounded-lg flex items-center"
+              className=" text-white bg-blue-500 hover:bg-white hover:text-blue-600  border-4 border-blue-700 font-bold p-4 mb-6 transition-all rounded-lg flex items-center"
             >
               Copy Hex Code
               <ContentCopyIcon fontSize="small" className="ml-2" />
             </button>
             <button
               onClick={handleRGB}
-              className="bg-blue-500 hover:bg-white hover:text-black hover:border-4 border-blue-700 font-bold p-4 mb-6 transition-all rounded-lg flex items-center"
+              className="text-white bg-blue-500 hover:bg-white hover:text-blue-600 border-4 border-blue-700 font-bold p-4 mb-6 transition-all rounded-lg flex items-center"
             >
               Copy RGB Code
               <ContentCopyIcon fontSize="small" className="ml-2" />


### PR DESCRIPTION
## Description
There was some extra items in navbar that is removed and made the download md file button responsive for different screens , changed button's color to green for better ux 
In about page, made some minor css changes to make goToGithub button visible.
color picker visiblity checked

Fixes #283 
Fixes #281 

## Type of change

-  Bug fix (non-breaking change which fixes an issue)


## Screenshots (if applicable):
![Screenshot (101)](https://github.com/user-attachments/assets/609f5385-72b1-4fb1-bdbf-a9c20a5ea462)
![Screenshot (102)](https://github.com/user-attachments/assets/e3597d9a-4433-4056-ac68-b5965e87e93e)


