### PR TITLE
issue 357 fixed preview button blocking

### DIFF
--- a/src/app/customizer/JsonGenerator/components/ActionButtons.jsx
+++ b/src/app/customizer/JsonGenerator/components/ActionButtons.jsx
@@ -5,7 +5,7 @@ export const ActionButtons = ({
   numRows,
   setNumRows,
 }) => (
-  <div className="fixed bottom-5 bg-white left-1/2 -translate-x-1/2 px-40 rounded flex gap-2 justify-center items-center py-2 dark:bg-gray-800">
+  <div className="fixed bottom-1 bg-white left-1/2 -translate-x-1/2 px-40 rounded flex gap-2 justify-center items-center py-2 dark:bg-gray-800">
     <button
       onClick={() => {
         setIsLoading(true);

--- a/src/app/customizer/JsonGenerator/components/CardForm.jsx
+++ b/src/app/customizer/JsonGenerator/components/CardForm.jsx
@@ -86,7 +86,7 @@ export default function CardForm({ isDarkMode }) {
 
   return (
     <Reorder.Group
-      className={`mt-10 ${isDarkMode ? "dark" : ""}`}
+      className={`mt-5 ${isDarkMode ? "dark" : ""}`}
       axis="y"
       values={fields}
       onReorder={setFields}

--- a/src/app/customizer/JsonGenerator/components/FieldsSection.jsx
+++ b/src/app/customizer/JsonGenerator/components/FieldsSection.jsx
@@ -12,23 +12,25 @@ export const FieldsSection = ({
   categoryData,
 }) => (
   <div className="flex flex-col">
-    <FieldHeader />
-    {fields.map((field) => (
-      <Reorder.Item
-        key={field.id}
-        value={field}
-        className="flex items-center bg-black-200 w-fit"
-      >
-        <Item
-          field={field}
-          handleChange={handleFieldChange}
-          removeField={removeField}
-          controls={controls}
-          categoryData={categoryData}
-          isDarkMode={isDarkMode}
-        />
-      </Reorder.Item>
-    ))}
+    {!!fields.length && <FieldHeader />}
+    <div className="h-40 overflow-auto">
+      {fields.map((field) => (
+        <Reorder.Item
+          key={field.id}
+          value={field}
+          className="flex items-center bg-black-200 w-fit"
+        >
+          <Item
+            field={field}
+            handleChange={handleFieldChange}
+            removeField={removeField}
+            controls={controls}
+            categoryData={categoryData}
+            isDarkMode={isDarkMode}
+          />
+        </Reorder.Item>
+      ))}
+    </div>
     <AddFieldButton onClick={addField} />
   </div>
 );

--- a/src/app/customizer/JsonGenerator/components/Heroish.jsx
+++ b/src/app/customizer/JsonGenerator/components/Heroish.jsx
@@ -1,6 +1,6 @@
 export default function Heroish() {
   return (
-    <div className="w-full mt-20">
+    <div className="w-full mt-6">
       <h1 className="relative z-10 font-sans text-lg font-bold text-center text-transparent md:text-7xl bg-clip-text bg-gradient-to-b from-neutral-200 to-neutral-600">
         Json Generator
       </h1>

--- a/src/app/customizer/JsonGenerator/components/Init.jsx
+++ b/src/app/customizer/JsonGenerator/components/Init.jsx
@@ -3,6 +3,4 @@ export const initialFields = () => [
   { id: uuidv4(), fieldName: "id", fieldType: "" },
   { id: uuidv4(), fieldName: "first_name", fieldType: "" },
   { id: uuidv4(), fieldName: "last_name", fieldType: "" },
-  { id: uuidv4(), fieldName: "email", fieldType: "" },
-  { id: uuidv4(), fieldName: "gender", fieldType: "" },
 ];


### PR DESCRIPTION
**Fixes** - [ #357]( https://github.com/Bashamega/WebDevTools/issues/357)

**Description** - 
This PR aims to avoid the blocking of Action buttons(preview button, Export button and rows input field) 
with underneath content(add another field button) in mobile and desktop view by

1 . creating a scrollable section for fields.
2 . adjusting the margins/bottom  in between to update the page layout properly.
3 . modifying `initialFields `to 3 as it has a scrollable section and  also to avoid clumsiness on the page layout. 
4 . hidden Field header(Field name, Field type) when there are no fields as these headings are not required to be shown when there are no fields.

 **Screenshots** - 
![mobileView](https://github.com/user-attachments/assets/dce7a504-da0c-4b6c-8c2a-4890c4a1b160)
![desktopView](https://github.com/user-attachments/assets/31710255-e176-4f5e-85ef-2a6cca9edc9b)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

Please feel free to suggest any changes, will update accordingly. Thank you.


